### PR TITLE
Fix fiber & cleanup project.go

### DIFF
--- a/internal/project/util.go
+++ b/internal/project/util.go
@@ -1,0 +1,37 @@
+package project
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+func executeCmd(name string, args []string, dir string) error {
+	command := exec.Command(name, args...)
+	command.Dir = dir
+	var out bytes.Buffer
+	command.Stdout = &out
+	if err := command.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func initGoMod(projectName string, appDir string) {
+	if err := executeCmd("go",
+		[]string{"mod", "init", projectName},
+		appDir); err != nil {
+		cobra.CheckErr(err)
+	}
+}
+
+func goGetPackage(appDir, packageName string) {
+	fmt.Printf("Package name is: %s\n", packageName)
+	if err := executeCmd("go",
+		[]string{"get", "-u", packageName},
+		appDir); err != nil {
+		cobra.CheckErr(err)
+	}
+}

--- a/internal/templates/fiber_server.go
+++ b/internal/templates/fiber_server.go
@@ -4,13 +4,13 @@ type FiberRouteTemplate struct {
 }
 
 func (c FiberRouteTemplate) Main() []byte {
-	return MainTemplate()
+	return MakeFiberMain()
 }
 func (c FiberRouteTemplate) Server() []byte {
-	return MakeHTTPServer()
+	return MakeFiberServer()
 }
 func (c FiberRouteTemplate) Routes() []byte {
-	return MakeFiberServer()
+	return MakeFiberRoutes()
 }
 
 func MakeFiberServer() []byte {


### PR DESCRIPTION
In this PR:- 

- Cleanup `project.go` file and divide functions.
- Fix Fiber Framework.